### PR TITLE
Retry sends

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1185,7 +1185,7 @@ class Bot(TelegramObject):
 
         urlopen_timeout = timeout + network_delay
 
-        result = self._post_message(url, data, Update, True, **kwargs)
+        result = self._post_message(url, data, Update, True, urlopen_timeout, **kwargs)
 
         if result:
             self.logger.debug('Got updates: %s', [u.update_id for u in result])

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -60,9 +60,15 @@ class Bot(TelegramObject):
         else:
             self.base_file_url = base_file_url + self.token
 
-        self.bot = None
+        self._bot = None
 
         self.logger = logging.getLogger(__name__)
+
+    @property
+    def bot(self):
+        if not self._bot:
+            self.getMe()
+        return self._bot
 
     @staticmethod
     def _validate_token(token):
@@ -76,35 +82,19 @@ class Bot(TelegramObject):
 
         return token
 
-    def info(func):
-
-        @functools.wraps(func)
-        def decorator(self, *args, **kwargs):
-            if not self.bot:
-                self.getMe()
-
-            result = func(self, *args, **kwargs)
-            return result
-
-        return decorator
-
     @property
-    @info
     def id(self):
         return self.bot.id
 
     @property
-    @info
     def first_name(self):
         return self.bot.first_name
 
     @property
-    @info
     def last_name(self):
         return self.bot.last_name
 
     @property
-    @info
     def username(self):
         return self.bot.username
 
@@ -171,7 +161,7 @@ class Bot(TelegramObject):
 
         result = request.get(url)
 
-        self.bot = User.de_json(result)
+        self._bot = User.de_json(result)
 
         return self.bot
 

--- a/telegram/userprofilephotos.py
+++ b/telegram/userprofilephotos.py
@@ -43,7 +43,7 @@ class UserProfilePhotos(TelegramObject):
     def de_json(data):
         """
         Args:
-            data (str):
+            data (dict):
 
         Returns:
             telegram.UserProfilePhotos:


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [x] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Link new and existing constants in docstrings instead of hard coded number and strings
    - [ ] Add new message types to `Message.effective_attachment`
    - [ ] Added new handlers for new update types
      - [ ] Add the handlers to the warning loop in the `ConversationHandler`
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - [ ] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`
